### PR TITLE
style: 전역 스타일 scoped 적용

### DIFF
--- a/ganadi/src/view/pages/Setting.vue
+++ b/ganadi/src/view/pages/Setting.vue
@@ -1,20 +1,21 @@
 <template>
-  <div class="card">
-    <Budget />
-    <SetDefault />
-    <SetCategory />
-  </div>
+    <div class="card">
+        <Budget />
+        <SetDefault />
+        <SetCategory />
+    </div>
 </template>
 <script setup>
 import Budget from '../components/Budget.vue';
 import SetCategory from '../components/SetCategory.vue';
 import SetDefault from '../components/SetDefault.vue';
 </script>
-<style>
+
+<style scoped>
 .card {
-  background: #f5f5f5;
-  padding: 20px;
-  border-radius: 16px;
-  /* width: 320px; */
+    background: #f5f5f5;
+    padding: 20px;
+    border-radius: 16px;
+    /* width: 320px; */
 }
 </style>


### PR DESCRIPTION
## 🔗 Related Issue

이슈 없음

## 📌 Description

카드 css 배경색 전체적으로 회색 되는 거 setting 페이지만 적용되게 변경

## ✅ Changes

- page/Setting.vue의 style에 scoped 적용

## 🧪 Test

- [x] 테스트 완료
- [x] 로컬 실행 확인

## 📸 Screenshot (optional)
<img width="499" height="850" alt="스크린샷 2026-04-10 오전 9 24 46" src="https://github.com/user-attachments/assets/3d9dffe6-9ae3-4838-b74b-4bb94b8ca02a" />
<img width="502" height="862" alt="스크린샷 2026-04-10 오전 9 24 54" src="https://github.com/user-attachments/assets/85cc54f1-a2e3-4643-80da-99e73a392de0" />

## 🚨 Notes
