### PR TITLE
feat: 선택한 달의 통계와 홈 페이지로 넘어가는 기능 추가

### DIFF
--- a/ganadi/src/stores/calendarStore.js
+++ b/ganadi/src/stores/calendarStore.js
@@ -1,0 +1,15 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+export const useCalendarStore = defineStore('calendar', () => {
+    const currentDate = ref(new Date());
+
+    const setDate = (date) => {
+        currentDate.value = new Date(date);
+    };
+
+    return {
+        currentDate,
+        setDate,
+    };
+});

--- a/ganadi/src/view/components/Footer.vue
+++ b/ganadi/src/view/components/Footer.vue
@@ -1,132 +1,153 @@
 <template>
-  <nav class="footer">
-    <ul class="menu">
-      <li v-for="menu in menus" :key="menu.path">
-        <router-link :to="menu.path" class="menu-item" active-class="active">
-          <i
-            :class="[
-              'bi',
-              isActive(menu.path) ? menu.activeIcon : menu.icon,
-              'icon',
-            ]"
-          ></i>
-          <span class="label">{{ menu.name }}</span>
-        </router-link>
-      </li>
-    </ul>
-  </nav>
+    <nav class="footer">
+        <ul class="menu">
+            <li v-for="menu in menus" :key="menu.path">
+                <router-link
+                    :to="getMenuTarget(menu)"
+                    class="menu-item"
+                    active-class="active"
+                >
+                    <i
+                        :class="[
+                            'bi',
+                            isActive(menu.path) ? menu.activeIcon : menu.icon,
+                            'icon',
+                        ]"
+                    ></i>
+                    <span class="label">{{ menu.name }}</span>
+                </router-link>
+            </li>
+        </ul>
+    </nav>
 </template>
 
 <script setup>
 import { useRoute } from 'vue-router';
+import { useCalendarStore } from '@/stores/calendarStore';
 
 const route = useRoute();
+const calendarStore = useCalendarStore();
 
 const menus = [
-  { name: '홈', path: '/', icon: 'bi-house', activeIcon: 'bi-house-fill' },
-  {
-    name: '통계',
-    path: '/graph',
-    icon: 'bi-bar-chart',
-    activeIcon: 'bi-bar-chart-fill',
-  },
-  {
-    name: '설정',
-    path: '/setting',
-    icon: 'bi-gear',
-    activeIcon: 'bi-gear-fill',
-  },
-  // {
-  //   name: '추가',
-  //   path: '/input',
-  //   icon: 'bi-plus',
-  //   activeIcon: 'bi-plus-circle-fill',
-  // },
+    { name: '홈', path: '/', icon: 'bi-house', activeIcon: 'bi-house-fill' },
+    {
+        name: '통계',
+        path: '/graph',
+        icon: 'bi-bar-chart',
+        activeIcon: 'bi-bar-chart-fill',
+    },
+    {
+        name: '설정',
+        path: '/setting',
+        icon: 'bi-gear',
+        activeIcon: 'bi-gear-fill',
+    },
+    // {
+    //   name: '추가',
+    //   path: '/input',
+    //   icon: 'bi-plus',
+    //   activeIcon: 'bi-plus-circle-fill',
+    // },
 ];
+
+const getMenuTarget = (menu) => {
+    const date = calendarStore.currentDate;
+    if (menu.path === '/graph' || menu.path === '/') {
+        return {
+            path: menu.path,
+            query: {
+                year: date.getFullYear(),
+                month: date.getMonth() + 1,
+            },
+        };
+    }
+
+    return { path: menu.path };
+};
 
 // 활성 메뉴 체크 (하위 경로 대응)
 const isActive = (path) => {
-  return route.path === path || route.path.startsWith(path + '/');
+    return route.path === path || route.path.startsWith(path + '/');
 };
 </script>
 
 <style scoped>
 .footer {
-  background: #dcdcdc;
-  border-top: 1px solid rgba(0, 0, 0, 0.1);
+    background: #dcdcdc;
+    border-top: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 .menu {
-  display: flex;
-  justify-content: space-around;
-  align-items: center;
-  padding: 14px 0;
-  margin: 0;
-  list-style: none;
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    padding: 14px 0;
+    margin: 0;
+    list-style: none;
 }
 
 .menu-item {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-  text-decoration: none;
-  color: #555;
-  font-size: 12px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    text-decoration: none;
+    color: #555;
+    font-size: 12px;
 }
 
 .icon {
-  font-size: 26px;
-  color: #333;
-  transition: all 0.2s ease;
+    font-size: 26px;
+    color: #333;
+    transition: all 0.2s ease;
 }
 
 .menu-item.active {
-  color: #000;
-  font-weight: 600;
+    color: #000;
+    font-weight: 600;
 }
 
 .menu-item.active .icon {
-  color: #000;
-  transform: scale(1.15);
+    color: #000;
+    transform: scale(1.15);
 }
 
 .label {
-  display: none;
+    display: none;
 }
 
 /* =========================
    💻 PC 버전
    ========================= */
 @media (min-width: 768px) {
-  .footer {
-    height: 100%;
-    border-top: none;
-    border-right: 1px solid rgba(0, 0, 0, 0.1);
-    padding: 20px 12px;
-  }
+    .footer {
+        height: 100%;
+        border-top: none;
+        border-right: 1px solid rgba(0, 0, 0, 0.1);
+        padding: 20px 12px;
+    }
 
-  .menu {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 20px;
-  }
+    .menu {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 20px;
+    }
 
-  .menu-item {
-    flex-direction: row;
-    gap: 16px;
-    font-size: 16px;
-    color: #555;
-  }
+    .menu-item {
+        flex-direction: row;
+        gap: 16px;
+        font-size: 16px;
+        color: #555;
+    }
 
-  .icon {
-    font-size: 22px;
-  }
+    .icon {
+        font-size: 22px;
+    }
 
-  .label {
-    display: inline;
-    font-size: 16px;
-    margin: 0;
-  }
+    .label {
+        display: inline;
+        font-size: 16px;
+        margin: 0;
+    }
 }
 </style>

--- a/ganadi/src/view/pages/Graph.vue
+++ b/ganadi/src/view/pages/Graph.vue
@@ -26,6 +26,7 @@
 
 <script setup>
 import { ref, onMounted, watch, computed } from 'vue';
+import { useRoute } from 'vue-router';
 import { useCharacterStore } from '@/stores/characterStore';
 
 import GraphMonthSelector from '../components/graph/graphMonthSelector.vue';
@@ -36,17 +37,25 @@ import GraphChart from '../components/graph/graphChart.vue';
 import { getGraphRawData } from '@/api/graphService';
 import { evaluateCharacterLevelIfNeeded } from '@/api/characterService';
 import { adaptGraphData } from '@/utils/graphAdapter';
-// import { graphMockData } from '@/model/mock/graphMockData';
+import { useCalendarStore } from '@/stores/calendarStore';
 
-// const graphData = graphMockData;
-
+const route = useRoute();
 const characterStore = useCharacterStore();
+const calendarStore = useCalendarStore();
+
 const now = new Date();
 const currentYear = now.getFullYear();
 const currentMonth = now.getMonth() + 1;
 
-const selectedYear = ref(now.getFullYear());
-const selectedMonth = ref(now.getMonth() + 1);
+const initialYear = route.query.year ? Number(route.query.year) : currentYear;
+const initialMonth = route.query.month
+    ? Number(route.query.month)
+    : currentMonth;
+
+const selectedYear = ref(initialYear);
+const selectedMonth = ref(initialMonth);
+
+calendarStore.setDate(new Date(initialYear, initialMonth - 1, 1));
 
 const rawData = ref(null);
 
@@ -118,6 +127,9 @@ onMounted(async () => {
 });
 
 watch([selectedYear, selectedMonth], () => {
+    calendarStore.setDate(
+        new Date(selectedYear.value, selectedMonth.value - 1, 1),
+    );
     updateGraphData();
 });
 </script>

--- a/ganadi/src/view/pages/Home.vue
+++ b/ganadi/src/view/pages/Home.vue
@@ -1,328 +1,354 @@
 <template>
-  <div class="card card-body">
-    <Header
-      :month="currentMonth"
-      @prev-month="goPreMonth"
-      @next-month="goNextMonth"
-      :expense="expense"
-      :income="income"
-      :balance="balance"
-    ></Header>
+    <div class="card card-body">
+        <Header
+            :month="currentMonth"
+            @prev-month="goPreMonth"
+            @next-month="goNextMonth"
+            :expense="expense"
+            :income="income"
+            :balance="balance"
+        ></Header>
 
-    <ProgressBar
-      bgcolor="#C0FFBE"
-      :completedRate="completed_rate"
-      :goalMoney="goal_money"
-    />
-    <CalendarView :items="items" :show-date="showDate" class="account-calendar">
-      <template #day-content="{ day }">
-        <div
-          class="day-cell"
-          :class="{ selected: selectedDate === formatDate(day) }"
-          @click="selectDate(formatDate(day))"
+        <ProgressBar
+            bgcolor="#C0FFBE"
+            :completedRate="completed_rate"
+            :goalMoney="goal_money"
+        />
+        <CalendarView
+            :items="items"
+            :show-date="showDate"
+            class="account-calendar"
         >
-          <!-- 날짜 숫자 -->
-          <div class="day-number">{{ day.getDate() }}</div>
-        </div>
-      </template>
-    </CalendarView>
-    <!-- 상세내역 -->
-    <DailyDetail
-      :selectedDate="selectedDate"
-      :transactions="transactions"
-      :categoryData="categoryData"
-    />
-    <RouterLink
-      :to="{ path: '/input', query: { date: selectedDate } }"
-      class="add-button"
-    >
-      <img
-        src="@/assets/images/home_image/add.png"
-        alt="plus"
-        class="plus-image"
-      />
-    </RouterLink>
-  </div>
+            <template #day-content="{ day }">
+                <div
+                    class="day-cell"
+                    :class="{ selected: selectedDate === formatDate(day) }"
+                    @click="selectDate(formatDate(day))"
+                >
+                    <!-- 날짜 숫자 -->
+                    <div class="day-number">{{ day.getDate() }}</div>
+                </div>
+            </template>
+        </CalendarView>
+        <!-- 상세내역 -->
+        <DailyDetail
+            :selectedDate="selectedDate"
+            :transactions="transactions"
+            :categoryData="categoryData"
+        />
+        <RouterLink
+            :to="{ path: '/input', query: { date: selectedDate } }"
+            class="add-button"
+        >
+            <img
+                src="@/assets/images/home_image/add.png"
+                alt="plus"
+                class="plus-image"
+            />
+        </RouterLink>
+    </div>
 </template>
 
 <script>
-import { ref, computed, onMounted, watch } from "vue";
-import { CalendarView } from "vue-simple-calendar";
-import "vue-simple-calendar/dist/vue-simple-calendar.css";
-import ProgressBar from "../components/ProgressBar.vue";
-import Header from "../components/Header.vue";
-import DailyDetail from "../components/DailyDetail.vue";
-import axios from "axios";
+import { ref, computed, onMounted, watch } from 'vue';
+import { useRoute } from 'vue-router';
+import { CalendarView } from 'vue-simple-calendar';
+import 'vue-simple-calendar/dist/vue-simple-calendar.css';
+import ProgressBar from '../components/ProgressBar.vue';
+import Header from '../components/Header.vue';
+import DailyDetail from '../components/DailyDetail.vue';
+import axios from 'axios';
 import {
-  getMonthlyExpense,
-  getMonthlyIncome,
-  getCategory,
-} from "@/utils/graphAdapter";
+    getMonthlyExpense,
+    getMonthlyIncome,
+    getCategory,
+} from '@/utils/graphAdapter';
+import { useCalendarStore } from '@/stores/calendarStore';
 
 export default {
-  name: "Home",
-  components: {
-    CalendarView,
-    ProgressBar,
-    Header,
-    DailyDetail,
-  },
+    name: 'Home',
+    components: {
+        CalendarView,
+        ProgressBar,
+        Header,
+        DailyDetail,
+    },
 
-  setup() {
-    const showDate = ref(new Date());
+    setup() {
+        const calendarStore = useCalendarStore();
+        const route = useRoute();
 
-    const items = ref([]);
+        const now = new Date();
 
-    // 기본 선택 날짜: 오늘
-    const selectedDate = ref(new Date().toISOString().split("T")[0]);
-    const selectDate = (date) => {
-      selectedDate.value = date;
-    };
+        const initialYear = route.query.year
+            ? Number(route.query.year)
+            : now.getFullYear();
+        const initialMonth = route.query.month
+            ? Number(route.query.month)
+            : now.getMonth() + 1;
 
-    const getTargetMonth = (dateObj) => {
-      const year = dateObj.getFullYear();
-      const month = String(dateObj.getMonth() + 1).padStart(2, "0");
-      return `${year}-${month}`;
-    };
-    const updateGoalMoney = () => {
-      const currentTargetMonth = getTargetMonth(showDate.value);
-      const currentBudget = budgetList.value.find(
-        (item) => item.targetMonth === currentTargetMonth,
-      );
-      goal_money.value = currentBudget ? Number(currentBudget.amount) : 0;
-    };
-    const transactions = ref([]);
-    const categoryData = ref([]);
-    onMounted(async () => {
-      try {
-        const [transRes, budRes, categoryRes, iconsRes, colorsRes] =
-          await Promise.all([
-            axios.get("/api/transactions"),
-            axios.get("/api/budget"),
-            axios.get("/api/category"),
-            axios.get("/api/icons"),
-            axios.get("/api/colors"),
-          ]);
-        transactions.value = transRes.data;
-        categoryData.value = getCategory(
-          categoryRes.data,
-          iconsRes.data,
-          colorsRes.data,
-        );
-        const budgetData = budRes.data;
-        budgetList.value = budgetData;
+        const showDate = ref(new Date(initialYear, initialMonth - 1, 1));
 
-        updateGoalMoney();
+        const items = ref([]);
 
-        const grouped = {};
+        // 기본 선택 날짜: 오늘
+        const selectedDate = ref(new Date().toISOString().split('T')[0]);
 
-        transactions.value.forEach((transaction) => {
-          const date = transaction.date;
+        // 처음 페이지 진입 시 현재 보고 있는 달 store에 저장
+        calendarStore.setDate(showDate.value);
 
-          if (!grouped[date]) {
-            grouped[date] = {
-              income: 0,
-              expense: 0,
-            };
-          }
+        const selectDate = (date) => {
+            selectedDate.value = date;
+        };
 
-          if (transaction.type === "income") {
-            grouped[date].income += Number(transaction.amount);
-          } else if (transaction.type === "expense") {
-            grouped[date].expense += Number(transaction.amount);
-          }
+        const getTargetMonth = (dateObj) => {
+            const year = dateObj.getFullYear();
+            const month = String(dateObj.getMonth() + 1).padStart(2, '0');
+            return `${year}-${month}`;
+        };
+        const updateGoalMoney = () => {
+            const currentTargetMonth = getTargetMonth(showDate.value);
+            const currentBudget = budgetList.value.find(
+                (item) => item.targetMonth === currentTargetMonth,
+            );
+            goal_money.value = currentBudget ? Number(currentBudget.amount) : 0;
+        };
+        const transactions = ref([]);
+        const categoryData = ref([]);
+        onMounted(async () => {
+            try {
+                const [transRes, budRes, categoryRes, iconsRes, colorsRes] =
+                    await Promise.all([
+                        axios.get('/api/transactions'),
+                        axios.get('/api/budget'),
+                        axios.get('/api/category'),
+                        axios.get('/api/icons'),
+                        axios.get('/api/colors'),
+                    ]);
+                transactions.value = transRes.data;
+                categoryData.value = getCategory(
+                    categoryRes.data,
+                    iconsRes.data,
+                    colorsRes.data,
+                );
+                const budgetData = budRes.data;
+                budgetList.value = budgetData;
+
+                updateGoalMoney();
+
+                const grouped = {};
+
+                transactions.value.forEach((transaction) => {
+                    const date = transaction.date;
+
+                    if (!grouped[date]) {
+                        grouped[date] = {
+                            income: 0,
+                            expense: 0,
+                        };
+                    }
+
+                    if (transaction.type === 'income') {
+                        grouped[date].income += Number(transaction.amount);
+                    } else if (transaction.type === 'expense') {
+                        grouped[date].expense += Number(transaction.amount);
+                    }
+                });
+
+                const transactionItems = [];
+
+                Object.keys(grouped).forEach((date) => {
+                    const dayData = grouped[date];
+
+                    if (dayData.income > 0) {
+                        transactionItems.push({
+                            id: Date.now(),
+                            startDate: date,
+                            endDate: date,
+                            title: '+' + dayData.income.toLocaleString(),
+                            classes: ['income-item'],
+                        });
+                    }
+
+                    if (dayData.expense > 0) {
+                        transactionItems.push({
+                            id: Date.now(),
+                            startDate: date,
+                            endDate: date,
+                            title: '-' + dayData.expense.toLocaleString(),
+                            classes: ['expense-item'],
+                        });
+                    }
+                });
+
+                items.value = transactionItems;
+            } catch (error) {
+                console.error('Error fetching transactions:', error);
+            }
+        });
+        //입금,소비,잔액,목표금액
+        const expense = computed(() => {
+            return getMonthlyExpense(
+                transactions.value,
+                showDate.value.getFullYear(),
+                showDate.value.getMonth() + 1,
+            );
+        });
+        const income = computed(() => {
+            return getMonthlyIncome(
+                transactions.value,
+                showDate.value.getFullYear(),
+                showDate.value.getMonth() + 1,
+            );
+        });
+        const balance = computed(() => {
+            return income.value - expense.value;
+        });
+        const goal_money = ref(0);
+        const budgetList = ref([]);
+        //달성률
+        const completed_rate = computed(() => {
+            if (goal_money.value === 0) return 0;
+            return Math.round((expense.value / goal_money.value) * 100);
         });
 
-        const transactionItems = [];
-
-        Object.keys(grouped).forEach((date) => {
-          const dayData = grouped[date];
-
-          if (dayData.income > 0) {
-            transactionItems.push({
-              id: Date.now(),
-              startDate: date,
-              endDate: date,
-              title: "+" + dayData.income.toLocaleString(),
-              classes: ["income-item"],
-            });
-          }
-
-          if (dayData.expense > 0) {
-            transactionItems.push({
-              id: Date.now(),
-              startDate: date,
-              endDate: date,
-              title: "-" + dayData.expense.toLocaleString(),
-              classes: ["expense-item"],
-            });
-          }
+        // showDate 바뀔 때마다 store 갱신
+        watch(showDate, (newDate) => {
+            updateGoalMoney();
+            calendarStore.setDate(newDate);
         });
 
-        items.value = transactionItems;
-      } catch (error) {
-        console.error("Error fetching transactions:", error);
-      }
-    });
-    //입금,소비,잔액,목표금액
-    const expense = computed(() => {
-      return getMonthlyExpense(
-        transactions.value,
-        showDate.value.getFullYear(),
-        showDate.value.getMonth() + 1,
-      );
-    });
-    const income = computed(() => {
-      return getMonthlyIncome(
-        transactions.value,
-        showDate.value.getFullYear(),
-        showDate.value.getMonth() + 1,
-      );
-    });
-    const balance = computed(() => {
-      return income.value - expense.value;
-    });
-    const goal_money = ref(0);
-    const budgetList = ref([]);
-    //달성률
-    const completed_rate = computed(() => {
-      if (goal_money.value === 0) return 0;
-      return Math.round((expense.value / goal_money.value) * 100);
-    });
-    watch(showDate, () => {
-      updateGoalMoney();
-    });
+        const currentMonth = computed(() => {
+            return showDate.value.getMonth() + 1; // 월은 0부터 시작하므로 +1
+        });
 
-    const currentMonth = computed(() => {
-      return showDate.value.getMonth() + 1; // 월은 0부터 시작하므로 +1
-    });
+        //이전 달로 이동
+        const goPreMonth = () => {
+            const d = showDate.value;
+            showDate.value = new Date(d.getFullYear(), d.getMonth() - 1, 1);
+        };
 
-    //이전 달로 이동
-    const goPreMonth = () => {
-      const d = showDate.value;
-      showDate.value = new Date(d.getFullYear(), d.getMonth() - 1, 1);
-    };
+        //다음 달로 이동
+        const goNextMonth = () => {
+            const d = showDate.value;
+            showDate.value = new Date(d.getFullYear(), d.getMonth() + 1, 1);
+        };
 
-    //다음 달로 이동
-    const goNextMonth = () => {
-      const d = showDate.value;
-      showDate.value = new Date(d.getFullYear(), d.getMonth() + 1, 1);
-    };
+        const formatDate = (dateObj) => {
+            const year = dateObj.getFullYear();
+            const month = String(dateObj.getMonth() + 1).padStart(2, '0');
+            const day = String(dateObj.getDate()).padStart(2, '0');
+            return `${year}-${month}-${day}`;
+        };
 
-    const formatDate = (dateObj) => {
-      const year = dateObj.getFullYear();
-      const month = String(dateObj.getMonth() + 1).padStart(2, "0");
-      const day = String(dateObj.getDate()).padStart(2, "0");
-      return `${year}-${month}-${day}`;
-    };
-    return {
-      showDate,
-      items,
-      currentMonth,
-      income,
-      expense,
-      balance,
-      completed_rate,
-      goal_money,
-      goPreMonth,
-      goNextMonth,
-      selectedDate,
-      selectDate,
-      formatDate,
-      transactions,
-      categoryData,
-    };
-  },
+        return {
+            showDate,
+            items,
+            currentMonth,
+            income,
+            expense,
+            balance,
+            completed_rate,
+            goal_money,
+            goPreMonth,
+            goNextMonth,
+            selectedDate,
+            selectDate,
+            formatDate,
+            transactions,
+            categoryData,
+        };
+    },
 };
 </script>
 
 <style>
 .add-button {
-  position: absolute;
-  bottom: 20px;
-  right: 20px;
-  width: 80px;
-  height: 80px;
-  border-radius: 50%;
-  background-color: white;
-  border: black 1px solid;
-  box-shadow: 0 8px 8px rgba(0, 0, 0, 0.3);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
+    position: absolute;
+    bottom: 20px;
+    right: 20px;
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    background-color: white;
+    border: black 1px solid;
+    box-shadow: 0 8px 8px rgba(0, 0, 0, 0.3);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
 }
 
 .add-button:hover {
-  transform: scale(1.1);
-  box-shadow: 0 8px 8px rgba(3, 3, 3, 2);
+    transform: scale(1.1);
+    box-shadow: 0 8px 8px rgba(3, 3, 3, 2);
 }
 
 .plus-image {
-  width: 70px;
-  height: 70px;
+    width: 70px;
+    height: 70px;
 }
 
 .card-body {
-  position: relative;
+    position: relative;
 }
 
 /* 데일리 수입/지출 내역과 그리드 너비 */
 .account-calendar .cv-item {
-  background: transparent !important;
-  border: none !important;
-  padding: 10px !important;
-  /* 각 셀에서 hover 버벅이는 문제 해결 코드 */
-  pointer-events: none;
+    background: transparent !important;
+    border: none !important;
+    padding: 10px !important;
+    /* 각 셀에서 hover 버벅이는 문제 해결 코드 */
+    pointer-events: none;
 }
 
 .account-calendar .cv-item.income-item {
-  color: rgb(30, 255, 0);
-  font-size: small;
+    color: rgb(30, 255, 0);
+    font-size: small;
 }
 .account-calendar .cv-item.expense-item {
-  color: rgb(255, 0, 0);
-  font-size: small;
+    color: rgb(255, 0, 0);
+    font-size: small;
 }
 
 .account-calendar .cv-week {
-  min-height: 80px !important;
+    min-height: 80px !important;
 }
 
 /* 오늘 날짜 표시 */
 .account-calendar .cv-day.today {
-  background-color: #efefef;
-  color: red;
-  font-weight: bold;
+    background-color: #efefef;
+    color: red;
+    font-weight: bold;
 }
 
 /* 날짜 셀 커스텀 */
 .day-cell {
-  width: 100%;
-  box-sizing: border-box;
-  padding: 5px;
-  cursor: pointer;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 5px;
+    cursor: pointer;
 }
 
 /* hover 효과 */
 .day-cell:hover {
-  background-color: #fff0fd;
+    background-color: #fff0fd;
 }
 
 /* 선택된 날짜 */
 .day-cell.selected {
-  border: 3px solid #ffd8fa;
-  background-color: #fff0fd;
+    border: 3px solid #ffd8fa;
+    background-color: #fff0fd;
 }
 
 /* 날짜 숫자 */
 .day-number {
-  font-weight: bold;
-  font-size: 14px;
-  margin-bottom: 4px;
+    font-weight: bold;
+    font-size: 14px;
+    margin-bottom: 4px;
 }
 .account-calendar .cv-day-number {
-  display: none;
+    display: none;
 }
 </style>


### PR DESCRIPTION
## 🔗 Related Issue

이슈 없슨

## 📌 Description

메인 페이지에서 선택한 달에서 통계 페이지 누르면 해당 월 통계로 넘어가는 기능

## ✅ Changes

- calendarStore.js 를 만들어서 월 데이터가 이동하게 만들었어염

## 🧪 Test

- [x] 테스트 완료
- [x] 로컬 실행 확인

## 📸 Screenshot (optional)

<img width="491" height="780" alt="스크린샷 2026-04-10 오후 5 03 52" src="https://github.com/user-attachments/assets/b017b022-f086-49ff-bae1-141aa39f6479" />
<img width="494" height="773" alt="스크린샷 2026-04-10 오후 5 04 02" src="https://github.com/user-attachments/assets/e390ed30-5f5a-4b64-ace5-31d3c010c0e7" />

## 🚨 Notes
